### PR TITLE
[packages] Codec published on testnet and mainnet

### DIFF
--- a/packages/codec/Move.lock
+++ b/packages/codec/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 2
-manifest_digest = "A3359BEEA070576E7B94445B73BDC1268128CDC0F6CBCC3428D9ACBAAFDC74E4"
+manifest_digest = "D91961D573877171BD322910BE217C8DB4870F4D2112860E10417F96B65A0EC5"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { name = "Sui" },
@@ -10,11 +10,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/mainnet", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/mainnet", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },
@@ -29,6 +29,6 @@ flavor = "sui"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0x8da612bc4f6eb8584d8577baffe858bf4b9d9373f3366c06dd69b3ab72fb6c66"
-latest-published-id = "0x8da612bc4f6eb8584d8577baffe858bf4b9d9373f3366c06dd69b3ab72fb6c66"
+original-published-id = "0xa11d4e236d3456c14edd263859c475bc539b43afb8b41fa10974ca0abca6a1c0"
+latest-published-id = "0xa11d4e236d3456c14edd263859c475bc539b43afb8b41fa10974ca0abca6a1c0"
 published-version = "1"

--- a/packages/codec/Move.lock
+++ b/packages/codec/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 2
-manifest_digest = "DA23D194C4FCA1530E5A47F6B4FE63019FB0C667FDB06BA13E9C580CB754C316"
+manifest_digest = "A3359BEEA070576E7B94445B73BDC1268128CDC0F6CBCC3428D9ACBAAFDC74E4"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { name = "Sui" },
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.30.3"
+compiler-version = "1.32.0"
 edition = "2024.beta"
 flavor = "sui"
 
@@ -29,6 +29,6 @@ flavor = "sui"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0x1aafdbe8c6233b3a1e4e40edc027f42c72d90c0afc5daf5e6df64aa3532ab14b"
-latest-published-id = "0x1aafdbe8c6233b3a1e4e40edc027f42c72d90c0afc5daf5e6df64aa3532ab14b"
+original-published-id = "0x8da612bc4f6eb8584d8577baffe858bf4b9d9373f3366c06dd69b3ab72fb6c66"
+latest-published-id = "0x8da612bc4f6eb8584d8577baffe858bf4b9d9373f3366c06dd69b3ab72fb6c66"
 published-version = "1"

--- a/packages/codec/Move.lock
+++ b/packages/codec/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 2
-manifest_digest = "D91961D573877171BD322910BE217C8DB4870F4D2112860E10417F96B65A0EC5"
+manifest_digest = "96F3726377B0B6EB00A248C93E50C64FF356FE5E4EBDB60E7483440D713BF3FB"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { name = "Sui" },
@@ -31,4 +31,10 @@ flavor = "sui"
 chain-id = "4c78adac"
 original-published-id = "0xa11d4e236d3456c14edd263859c475bc539b43afb8b41fa10974ca0abca6a1c0"
 latest-published-id = "0xa11d4e236d3456c14edd263859c475bc539b43afb8b41fa10974ca0abca6a1c0"
+published-version = "1"
+
+[env.mainnet]
+chain-id = "35834a8a"
+original-published-id = "0xea15ee7c28ff237eeb8fa1fe64b507ab97c352a46bba54b67fa751dde42696e5"
+latest-published-id = "0xea15ee7c28ff237eeb8fa1fe64b507ab97c352a46bba54b67fa751dde42696e5"
 published-version = "1"

--- a/packages/codec/Move.toml
+++ b/packages/codec/Move.toml
@@ -9,3 +9,4 @@ Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-fram
 [addresses]
 codec = "0x0"
 codec_testnet_upgrade_cap = "0xb3356ec1937e93fbe3ce9f5408d34abbc6ee2ad06cbeb4aa917bd80d8954bcb7"
+codec_mainnet_upgrade_cap = "0x9656fad9500d5b2df614f10e14f07b421c566079c852eb094269c0326e4bc212"

--- a/packages/codec/Move.toml
+++ b/packages/codec/Move.toml
@@ -4,8 +4,7 @@ edition = "2024.beta"
 authors = ["Sui Potatoes"]
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
-codec = "0x1aafdbe8c6233b3a1e4e40edc027f42c72d90c0afc5daf5e6df64aa3532ab14b"
-codec_upgrade_cap = "0x9d39ae387050527798b3b13bfdd8b3d10402f4c108bbad067c788e7abdbc94a7"
+codec = "0x0"

--- a/packages/codec/Move.toml
+++ b/packages/codec/Move.toml
@@ -8,3 +8,4 @@ Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-fram
 
 [addresses]
 codec = "0x0"
+codec_testnet_upgrade_cap = "0xb3356ec1937e93fbe3ce9f5408d34abbc6ee2ad06cbeb4aa917bd80d8954bcb7"

--- a/packages/codec/README.md
+++ b/packages/codec/README.md
@@ -16,8 +16,16 @@ To add this library to your project, add this to your `Move.toml` file under
 
 ```toml
 # goes into [dependencies] section
-Codec = { git = "https://github.com/sui-potatoes/app.git", subdir = "packages/codec", rev = "main" }
+Codec = { git = "https://github.com/sui-potatoes/app.git", subdir = "packages/codec", rev = "codec@testnet-v1" }
 ```
+
+If you need a **mainnet** version of this package, use the `mainnet-v1` tag instead:
+
+```toml
+# goes into [dependencies] section
+Codec = { git = "https://github.com/sui-potatoes/app.git", subdir = "packages/codec", rev = "codec@mainnet-v1" }
+```
+
 
 Exported address of this package is:
 

--- a/packages/codec/README.md
+++ b/packages/codec/README.md
@@ -30,7 +30,7 @@ Codec = { git = "https://github.com/sui-potatoes/app.git", subdir = "packages/co
 Exported address of this package is:
 
 ```toml
-encoding = "0x..."
+codec = "0x..."
 ```
 
 In your code, import and use the package as:

--- a/packages/codec/README.md
+++ b/packages/codec/README.md
@@ -54,7 +54,7 @@ is always `std::string::String`.
 
 ```rust
 use std::string::String;
-use potatoes::hex;
+use codec::hex;
 
 // while the type annotation is not necessary, we've added it to be explicit
 let encoded: String = hex::encode(b"hello, potato!"); // takes vector<u8>


### PR DESCRIPTION
Updates the README, we now suggest the following tag structure for published packages:

```move
codec@testnet-v1
svg@mainnet-v2
```

Versions and their addresses are stored in the Move.lock files.